### PR TITLE
Removes -lrt flag from macosx compile

### DIFF
--- a/nimrdkafka.nim
+++ b/nimrdkafka.nim
@@ -45,8 +45,8 @@
 #  I.e.: 0x00080100 = 0.8.1
 # 
 {.deadCodeElim: on.}
-{.passL: "-lz -lpthread -lrt" .}
-
+{.passL: "-lz -lpthread" .}
+ 
 when defined(windows): 
   const 
     librdkafka* = "librdkafka.dll"

--- a/nimrdkafka.nimble
+++ b/nimrdkafka.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.1.3"
+version       = "0.1.4"
 author        = "Didier Deshommes"
 description   = "Low-level Nim wrapper for librdkafka"
 license       = "MIT"


### PR DESCRIPTION
The -lrt flag is not supported on macOS, actually
glibc after 2.17 (2013ish) no longer needs -lrt so
recent Linux dists should be fine anyway. Regardless
this is needed on MacOS to compile.

Fixes #9 