### PR TITLE
Adds rd_kafka_topic_partition_list_destroy function

### DIFF
--- a/nimrdkafka.nim
+++ b/nimrdkafka.nim
@@ -1047,6 +1047,12 @@ proc rd_kafka_topic_partition_list_add*(
     importc: "rd_kafka_topic_partition_list_add", dynlib: librdkafka.}
     ##Add topic+partition to list
 
+proc rd_kafka_topic_partition_list_destroy*(
+    topicPartitionList: PRDKTopicPartitionList
+) {.cdecl,
+ importc: "rd_kafka_topic_partition_list_destroy", dynlib: librdkafka.} 
+ ##Free all resources used by the list and the list itself.
+
 proc rd_kafka_consumer_close*(rk: PRDK): RDKResponseError {.cdecl
     importc: "rd_kafka_consumer_close", dynlib: librdkafka.}
     #Close down the KafkaConsumer.

--- a/nimrdkafka.nimble
+++ b/nimrdkafka.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Didier Deshommes"
 description   = "Low-level Nim wrapper for librdkafka"
 license       = "MIT"


### PR DESCRIPTION
@dfdeshom  
This adds rd_kafka_topic_partition_list_destroy function. It is in librdkafka .1.6.2 as you can see in (https://github.com/edenhill/librdkafka/blob/v1.6.2/src/rdkafka.h#L940).