### PR TITLE
Add commit meesage API to library

### DIFF
--- a/nimrdkafka.nim
+++ b/nimrdkafka.nim
@@ -1029,6 +1029,11 @@ proc rd_kafka_commit*(rk: PRDK, offset: PRDKTopicPartitionList, async: cint): RD
     ##Commit message's offset on broker for the message's partition.
     ##The committed offset is the message's offset + 1.
 
+proc rd_kafka_commit_message*(rk: PRDK, message: PRDKMessage, async: cint): RDKResponseError {.cdecl,
+    importc: "rd_kafka_commit_message", dynlib: librdkafka.} ## \
+    ##Commit message's offset on broker for the message's partition. 
+    ##The committed offset is the message's offset + 1.
+
 proc rd_kafka_consumer_poll*(rk: PRDK, timeout_ms: cint): PRDKMessage {.cdecl,
     importc: "rd_kafka_consumer_poll", dynlib: librdkafka.} ##\
     ## Close down the KafkaConsumer.

--- a/nimrdkafka.nimble
+++ b/nimrdkafka.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.2.2"
+version       = "0.2.3"
 author        = "Didier Deshommes"
 description   = "Low-level Nim wrapper for librdkafka"
 license       = "MIT"


### PR DESCRIPTION
@dfdeshom
As we need these api in our development. Would you please approve this change that adds this API to library that support committing offset manually. Thank you in advance.

```nim
proc rd_kafka_commit_message*(rk: PRDK, message: PRDKMessage, async: cint): RDKResponseError {.cdecl,
    importc: "rd_kafka_commit_message", dynlib: librdkafka.} ## \
    ##Commit message's offset on broker for the message's partition. 
    ##The committed offset is the message's offset + 1.
```